### PR TITLE
重複チェック

### DIFF
--- a/join/index.php
+++ b/join/index.php
@@ -1,5 +1,6 @@
 <?php
 session_start();
+require('../dbconnect.php');
 
 if (!empty($_POST)) {
 	if ($_POST['name'] === '') {
@@ -19,6 +20,16 @@ if (!empty($_POST)) {
 		$ext = substr($fileName, -3);
 		if ($ext != 'jpg' && $ext != 'gif' && $ext != 'png') {
 			$error['image'] = 'type';
+		}
+	}
+
+	//アカウントの重複のチェック
+	if(empty($error)) {
+		$member = $db->prepare('SELECT COUNT(*) AS cnt FROM members WHERE email=?');
+		$member->execute(array($_POST['email']));
+		$record = $member->fetch();
+		if ($record['cnt'] > 0) {
+			$error['email'] = 'duplicate';
 		}
 	}
 
@@ -70,6 +81,9 @@ if ($_REQUEST['action'] == 'rewrite' && isset($_SESSION['join'])) {
 					ENT_QUOTES)); ?>" />
 					<?php if ($error['email'] === 'blank'): ?>
 					<p class="error">*メールアドレスを入力してください</p>
+					<?php endif; ?>
+					<?php if ($error['email'] === 'duplicate'): ?>
+					<p class="error">*指定されたメールアドレスは、既に登録されています</p>
 					<?php endif; ?>
 		<dt>パスワード<span class="required">必須</span></dt>
 		<dd>


### PR DESCRIPTION
What:
メールアドレスの重複をチェックする機能の実装

Why:
重複してアカウントの作成ができてしまうとどちらのアカウントか判断がつかない為
重複したメールアドレスの登録をできないようにしました。